### PR TITLE
Readme and FastAPI import fix.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -36,10 +36,10 @@ Uniform JSON logging for **University Medicine Essen** applications.
 ## 📦 Installation
 
 ```bash
-pip install logging-ume
+pip install ume-logging
 # Optional extras:
-pip install "logging-ume[fastapi]"   # FastAPI request logging middleware
-pip install "logging-ume[otel]"      # OpenTelemetry tracing + span events
+pip install "ume-logging[fastapi]"   # FastAPI request logging middleware
+pip install "ume-logging[otel]"      # OpenTelemetry tracing + span events
 ```
 
 ---

--- a/python/umelogging/__init__.py
+++ b/python/umelogging/__init__.py
@@ -1,6 +1,10 @@
 # Purpose: Public API surface for UME logging
 from .config import log_configure, set_context
-from .fastapi.middleware import UMERequestLoggerMiddleware  # optional; fails gracefully if FastAPI absent
+# fails gracefully if FastAPI absent
+try:
+    from .fastapi.middleware import UMERequestLoggerMiddleware
+except ImportError:
+    UMERequestLoggerMiddleware = None
 from .formatter import JsonFormatter
 from .context import request_id_var, update_context, get_context, with_request_id
 


### PR DESCRIPTION
readme package name corrected, fastapi gracefull import fixed wrapping it into try catch. Before, fastapi needed to be installed, so the option without fastapi was not working.